### PR TITLE
authNRequest fixes and other changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ hs_err_pid*
 #idea
 *.iml
 .idea
+
+spid-spring-integration/target/
+spid-spring-rest/target/
+spid-spring-integration/bin/

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,11 @@
 			<artifactId>spring-core</artifactId>
 			<version>${spring.version}</version>
 		</dependency>
-
+		<dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.20</version>
+        </dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-test</artifactId>

--- a/spid-spring-integration/src/main/java/it/italia/developers/spid/integration/config/SAMLConfig.java
+++ b/spid-spring-integration/src/main/java/it/italia/developers/spid/integration/config/SAMLConfig.java
@@ -1,5 +1,8 @@
 package it.italia.developers.spid.integration.config;
 
+import lombok.Data;
+
+@Data
 public class SAMLConfig {
 
 	private String idpEntityId;
@@ -11,65 +14,4 @@ public class SAMLConfig {
 	private String alias;
 	private String defaultBaseUrl;
 	private String x509Certificate;
-
-	public String getIdpEntityId() {
-		return idpEntityId;
-	}
-
-	public void setIdpEntityId(final String idpEntityId) {
-		this.idpEntityId = idpEntityId;
-	}
-
-	public String getX509Certificate() {
-		return x509Certificate;
-	}
-
-	public void setX509Certificate(final String x509Certificate) {
-		this.x509Certificate = x509Certificate;
-	}
-
-	public String getSpEntityId() {
-		return spEntityId;
-	}
-
-	public void setSpEntityId(final String spEntityId) {
-		this.spEntityId = spEntityId;
-	}
-
-	public String getDefaultBaseUrl() {
-		return defaultBaseUrl;
-	}
-
-	public void setDefaultBaseUrl(final String defaultBaseUrl) {
-		this.defaultBaseUrl = defaultBaseUrl;
-	}
-
-	public String getLoginUrl() {
-		return loginUrl;
-	}
-
-	public void setLoginUrl(final String loginUrl) {
-		this.loginUrl = loginUrl;
-	}
-
-	public String getLogoutUrl() {
-		return logoutUrl;
-	}
-
-	public void setLogoutUrl(final String logoutUrl) {
-		this.logoutUrl = logoutUrl;
-	}
-
-	public String getBaseUrl() {
-		return defaultBaseUrl;
-	}
-
-	public String getAlias() {
-		return alias;
-	}
-
-	public void setAlias(final String alias) {
-		this.alias = alias;
-	}
-
 }

--- a/spid-spring-integration/src/main/java/it/italia/developers/spid/integration/config/SAMLContext.java
+++ b/spid-spring-integration/src/main/java/it/italia/developers/spid/integration/config/SAMLContext.java
@@ -29,10 +29,14 @@ import org.springframework.security.saml.processor.SAMLBinding;
 import org.springframework.security.saml.processor.SAMLProcessor;
 import org.springframework.security.saml.processor.SAMLProcessorImpl;
 
+import lombok.Getter;
+
 public class SAMLContext {
 	private static final Logger logger = LoggerFactory.getLogger(SAMLContext.class);
+	
+	@Getter
 	private static final SAMLProcessor samlProcessor;
-
+	@Getter
 	private MetadataManager metadataManager;
 	private KeyManager idpKeyManager;
 
@@ -86,18 +90,6 @@ public class SAMLContext {
 		context.setCommunicationProfileId(SAMLConstants.SAML2_WEBSSO_PROFILE_URI);
 
 		return context;
-	}
-
-	public SAMLProcessor getSamlProcessor() {
-		return samlProcessor;
-	}
-
-	public MetadataManager getMetadataManager() {
-		return metadataManager;
-	}
-
-	public KeyManager getIdpKeyManager() {
-		return idpKeyManager;
 	}
 
 	private String getDefaultBaseURL(final HttpServletRequest request) {

--- a/spid-spring-integration/src/main/java/it/italia/developers/spid/integration/config/SpMetadataGenerator.java
+++ b/spid-spring-integration/src/main/java/it/italia/developers/spid/integration/config/SpMetadataGenerator.java
@@ -23,7 +23,7 @@ public class SpMetadataGenerator {
 
 	    // Defaults
 	    String alias = configuration.getAlias();
-	    String baseURL = configuration.getBaseUrl();
+	    String baseURL = configuration.getDefaultBaseUrl();
 
 	    generator.setEntityBaseURL(baseURL);
 	    List<String> ssoBindings = new ArrayList<String>();

--- a/spid-spring-integration/src/main/java/it/italia/developers/spid/integration/service/impl/SPIDIntegrationServiceImpl.java
+++ b/spid-spring-integration/src/main/java/it/italia/developers/spid/integration/service/impl/SPIDIntegrationServiceImpl.java
@@ -111,14 +111,14 @@ public class SPIDIntegrationServiceImpl implements SPIDIntegrationService {
 			SAMLMessageContext messageContext = context.createSamlMessageContext(request, response);
 
 			// Process response
-			context.getSamlProcessor().retrieveMessage(messageContext);
+			SAMLContext.getSamlProcessor().retrieveMessage(messageContext);
 
 			messageContext
 					.setLocalEntityEndpoint(SAMLUtil.getEndpoint(messageContext.getLocalEntityRoleMetadata().getEndpoints(),
 							messageContext.getInboundSAMLBinding(), new HttpServletRequestAdapter(request)));
 			messageContext.getPeerEntityMetadata().setEntityID(saml2Config.getIdpEntityId());
 
-			WebSSOProfileConsumer consumer = new WebSSOProfileConsumerImpl(context.getSamlProcessor(),
+			WebSSOProfileConsumer consumer = new WebSSOProfileConsumerImpl(SAMLContext.getSamlProcessor(),
 					context.getMetadataManager());
 			credential = consumer.processAuthenticationResponse(messageContext);
 		}

--- a/spid-spring-integration/src/main/java/it/italia/developers/spid/integration/util/AuthenticationInfoExtractor.java
+++ b/spid-spring-integration/src/main/java/it/italia/developers/spid/integration/util/AuthenticationInfoExtractor.java
@@ -46,6 +46,7 @@ public class AuthenticationInfoExtractor {
 	private static final String SAML2_PROTOCOL = "urn:oasis:names:tc:SAML:2.0:protocol";
 	private static final String SAML2_POST_BINDING = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST";
 	private static final String SAML2_NAME_ID_POLICY = "urn:oasis:names:tc:SAML:2.0:nameid-format:transient";
+	private static final String SAML2_ISSUER = "urn:oasis:names:tc:SAML:2.0:nameid-format:entity";
 	private static final String SAML2_PASSWORD_PROTECTED_TRANSPORT = "https://www.spid.gov.it/SpidL2";
 	private static final String SAML2_ASSERTION = "urn:oasis:names:tc:SAML:2.0:assertion";
 	private static final String SPID_SPRING_INTEGRATION_IDP_PREFIX = "spid.spring.integration.idp.";
@@ -114,8 +115,8 @@ public class AuthenticationInfoExtractor {
 			}
 
 			// Caricamento IDP da entityID
-			AuthnRequest buildAuthenticationRequest = buildAuthenticationRequest(assertionConsumerServiceUrl, assertionConsumerServiceIndex, spEntityDescriptor.getEntityID(), id, destination);
-			String encodedAuthnRequest = spidIntegrationUtil.encodeAndPrintAuthnRequest(buildAuthenticationRequest);
+			AuthnRequest authnRequest = buildAuthenticationRequest(assertionConsumerServiceUrl, assertionConsumerServiceIndex, spEntityDescriptor.getEntityID(), id, destination);
+			String encodedAuthnRequest = spidIntegrationUtil.encodeAuthnRequest(authnRequest, false);
 
 			// TODO caricare da metadati SP
 			authRequest.setDestinationUrl(destination);
@@ -188,10 +189,11 @@ public class AuthenticationInfoExtractor {
 		AuthnRequestBuilder authRequestBuilder = new AuthnRequestBuilder();
 
 		AuthnRequest authRequest = authRequestBuilder.buildObject(SAML2_PROTOCOL, "AuthnRequest", "samlp");
-		authRequest.setIsPassive(Boolean.FALSE);
+		authRequest.setForceAuthn(Boolean.TRUE);
+		// authRequest.setIsPassive(Boolean.FALSE);
 		authRequest.setIssueInstant(issueInstant);
-		authRequest.setProtocolBinding(SAML2_POST_BINDING);
-		authRequest.setAssertionConsumerServiceURL(assertionConsumerServiceUrl);
+		// authRequest.setProtocolBinding(SAML2_POST_BINDING);
+		// authRequest.setAssertionConsumerServiceURL(assertionConsumerServiceUrl);
 		authRequest.setAssertionConsumerServiceIndex(assertionConsumerServiceIndex);
 		authRequest.setIssuer(buildIssuer(issuerId));
 		authRequest.setNameIDPolicy(buildNameIDPolicy());
@@ -233,7 +235,7 @@ public class AuthenticationInfoExtractor {
 		IssuerBuilder issuerBuilder = new IssuerBuilder();
 		Issuer issuer = issuerBuilder.buildObject();
 		issuer.setNameQualifier(issuerId);
-		issuer.setFormat(SAML2_NAME_ID_POLICY);
+		issuer.setFormat(SAML2_ISSUER);
 		issuer.setValue(issuerId);
 		return issuer;
 	}

--- a/spid-spring-integration/src/main/java/it/italia/developers/spid/integration/util/AuthenticationInfoExtractor.java
+++ b/spid-spring-integration/src/main/java/it/italia/developers/spid/integration/util/AuthenticationInfoExtractor.java
@@ -190,10 +190,7 @@ public class AuthenticationInfoExtractor {
 
 		AuthnRequest authRequest = authRequestBuilder.buildObject(SAML2_PROTOCOL, "AuthnRequest", "samlp");
 		authRequest.setForceAuthn(Boolean.TRUE);
-		// authRequest.setIsPassive(Boolean.FALSE);
 		authRequest.setIssueInstant(issueInstant);
-		// authRequest.setProtocolBinding(SAML2_POST_BINDING);
-		// authRequest.setAssertionConsumerServiceURL(assertionConsumerServiceUrl);
 		authRequest.setAssertionConsumerServiceIndex(assertionConsumerServiceIndex);
 		authRequest.setIssuer(buildIssuer(issuerId));
 		authRequest.setNameIDPolicy(buildNameIDPolicy());

--- a/spid-spring-integration/src/main/java/it/italia/developers/spid/integration/util/AuthenticationInfoExtractor.java
+++ b/spid-spring-integration/src/main/java/it/italia/developers/spid/integration/util/AuthenticationInfoExtractor.java
@@ -220,7 +220,7 @@ public class AuthenticationInfoExtractor {
 		// Create RequestedAuthnContext
 		RequestedAuthnContextBuilder requestedAuthnContextBuilder = new RequestedAuthnContextBuilder();
 		RequestedAuthnContext requestedAuthnContext = requestedAuthnContextBuilder.buildObject();
-		requestedAuthnContext.setComparison(AuthnContextComparisonTypeEnumeration.EXACT);
+		requestedAuthnContext.setComparison(AuthnContextComparisonTypeEnumeration.MINIMUM);
 		requestedAuthnContext.getAuthnContextClassRefs().add(authnContextClassRef);
 
 		return requestedAuthnContext;

--- a/spid-spring-integration/src/main/java/it/italia/developers/spid/integration/util/SPIDIntegrationUtil.java
+++ b/spid-spring-integration/src/main/java/it/italia/developers/spid/integration/util/SPIDIntegrationUtil.java
@@ -139,7 +139,8 @@ public class SPIDIntegrationUtil {
 		try {
 			Signer.signObject(authnRequest.getSignature());
 		} catch (SignatureException e) {
-			  e.printStackTrace();
+			log.error("There was an error while signing the request", e);
+			throw new IntegrationServiceException(e);
 		}
 		
 		// converting to a DOM

--- a/spid-spring-integration/src/main/java/it/italia/developers/spid/integration/util/SPIDIntegrationUtil.java
+++ b/spid-spring-integration/src/main/java/it/italia/developers/spid/integration/util/SPIDIntegrationUtil.java
@@ -184,8 +184,6 @@ public class SPIDIntegrationUtil {
 		credential.setEntityCertificate(certificate);
 		credential.setPrivateKey(pk);
 
-		// log.info("Private Key" + pk.toString());
-
 		return credential;
 	}
 
@@ -235,7 +233,6 @@ public class SPIDIntegrationUtil {
 		KeyStore ks = getKeyStore();
 		try {
 			X509Certificate certificate = (X509Certificate) ks.getCertificate(certificateAliasName);
-			// KeyInfoHelper.addPublicKey(keyInfo, certificate.getPublicKey());
 			KeyInfoHelper.addCertificate(keyInfo, certificate);
 		}
 		catch (CertificateEncodingException e) {

--- a/spid-spring-integration/src/main/java/it/italia/developers/spid/integration/util/SPIDIntegrationUtil.java
+++ b/spid-spring-integration/src/main/java/it/italia/developers/spid/integration/util/SPIDIntegrationUtil.java
@@ -139,7 +139,6 @@ public class SPIDIntegrationUtil {
 		try {
 			Signer.signObject(authnRequest.getSignature());
 		} catch (SignatureException e) {
-			log.error("There was an error while signing the request", e);
 			throw new IntegrationServiceException(e);
 		}
 		

--- a/spid-spring-rest/src/main/java/it/italia/developers/spid/spidspringrest/SpidSpringRestApplication.java
+++ b/spid-spring-rest/src/main/java/it/italia/developers/spid/spidspringrest/SpidSpringRestApplication.java
@@ -38,11 +38,6 @@ public class SpidSpringRestApplication {
 	@Bean
 	public Docket api() {
 		return new Docket(DocumentationType.SWAGGER_2).select().apis(RequestHandlerSelectors.any()).paths(PathSelectors.any()).build().apiInfo(apiInfo());
-		// .useDefaultResponseMessages(false)
-		// .globalResponseMessage(RequestMethod.GET, errorList())
-		// .globalResponseMessage(RequestMethod.POST, errorList())
-		// .globalResponseMessage(RequestMethod.PUT, errorList())
-		// .globalResponseMessage(RequestMethod.DELETE, errorList());
 	}
 
 	private List<ResponseMessage> errorList() {

--- a/spid-spring-rest/src/main/java/it/italia/developers/spid/spidspringrest/model/ExtraInfo.java
+++ b/spid-spring-rest/src/main/java/it/italia/developers/spid/spidspringrest/model/ExtraInfo.java
@@ -1,28 +1,12 @@
 package it.italia.developers.spid.spidspringrest.model;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
 public class ExtraInfo {
 
 	private String title;
 	private String url;
-
-	public ExtraInfo() {
-	}
-
-	public ExtraInfo(final String title, final String url) {
-		this.title = title;
-		this.url = url;
-	}
-
-	public String getTitle() {
-		return title;
-	}
-	public void setTitle(final String title) {
-		this.title = title;
-	}
-	public String getUrl() {
-		return url;
-	}
-	public void setUrl(final String url) {
-		this.url = url;
-	}
 }

--- a/spid-spring-rest/src/main/java/it/italia/developers/spid/spidspringrest/model/SpidProviders.java
+++ b/spid-spring-rest/src/main/java/it/italia/developers/spid/spidspringrest/model/SpidProviders.java
@@ -3,22 +3,11 @@ package it.italia.developers.spid.spidspringrest.model;
 import java.util.List;
 
 import it.italia.developers.spid.integration.model.IdpEntry;
+import lombok.Data;
 
+@Data
 public class SpidProviders {
 
 	private List<IdpEntry> identityProviders;
 	private List<ExtraInfo> extraInfo;
-
-	public List<IdpEntry> getIdentityProviders() {
-		return identityProviders;
-	}
-	public void setIdentityProviders(final List<IdpEntry> identityProviders) {
-		this.identityProviders = identityProviders;
-	}
-	public List<ExtraInfo> getExtraInfo() {
-		return extraInfo;
-	}
-	public void setExtraInfo(final List<ExtraInfo> extraInfo) {
-		this.extraInfo = extraInfo;
-	}
 }


### PR DESCRIPTION
### AuthNRequest fixes
- isPassive attribute is not allowed  (partially addresses #11)

see https://docs.italia.it/italia/spid/spid-regole-tecniche/it/stabile/single-sign-on.html

> nell’elemento <AuthnRequest> non deve essere presente l’attributo IsPassive (ad indicare false come valore di default)

see https://www.spid.gov.it/assets/download/SPID_QAD.pdf

> 2.1.11 - The IsPassive attribute must not be present

- both AssertionConsumerServiceIndex and AssertionConsumerServiceUrl+ProtocolBinding must not be set (partially addresses #11)

From spid-testenv2 validation:

> "Uno e uno solo uno tra gli attributi o gruppi di attributi devono essere presenti: [AssertionConsumerServiceIndex, [AssertionConsumerServiceUrl, ProtocolBinding]]"

see https://docs.italia.it/italia/spid/spid-regole-tecniche/it/stabile/single-sign-on.html

> In alternativa all’attributo AssertionConsumerServiceIndex (scelta sconsigliata) possono essere presenti:
l’attributo AssertionConsumerServiceURL [...]
l’attributo ProtocolBinding [...]

- ForceAuthn attribute must be present if SPID level > 1 (partially addresses #11)

see https://docs.italia.it/italia/spid/spid-regole-tecniche/it/stabile/single-sign-on.html

> l’attributo ForceAuthn nel caso in cui si richieda livelli di autenticazione superiori a SpidL1 (SpidL2 o SpidL3)

- Issuer must be set to "urn:oasis:names:tc:SAML:2.0:nameid-format:entity" not to "urn:oasis:names:tc:SAML:2.0:nameid-format:transient" (partially addresses #11)

see https://docs.italia.it/italia/spid/spid-regole-tecniche/it/stabile/single-sign-on.html

> L’elemento deve riportare gli attributi: Format fissato al valore urn:oasis:names:tc:SAML:2.0:nameid-format:entity

see https://www.spid.gov.it/assets/download/SPID_QAD.pdf

> 2.2.4 - The Format attribute must be urn:oasis:names:tc:SAML:2.0:nameidformat:entity

- The same public key info is provided twice in getSignature() (explicitly and via certificate), resulting in having both KeyValue and X509Data elements present in the AuthnRequest, making signxml throwing an exception when using spid-testenv2. Fixes #10.

see https://github.com/XML-Security/signxml/issues/143

As a fix, public key info is now only added via certificate (commenting KeyInfoHelper.addPublicKey(keyInfo, certificate.getPublicKey()); in getSignature()) and adding Signer.signObject(authnRequest.getSignature()); to printAuthnRequest

see https://github.com/italia/spid-testenv2/issues/325

- comparison set to MINIMUM in AuthNContext (partially addresses #11)

### Other minor changes:
- added maven generated dirs to .gitignore
- privateKey must not be logged
- option to not compress authnrequest when using POST binding (partially addresses #11)
- added lombok