### PR TITLE
Bugfix/update log4j

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,6 @@ hs_err_pid*
 #idea
 *.iml
 .idea
-/spid-spring-integration/target/
-/spid-spring-rest/target/
+
+#maven
+target/

--- a/spid-spring-integration/pom.xml
+++ b/spid-spring-integration/pom.xml
@@ -34,7 +34,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-slf4j-impl</artifactId>
-			<version>2.9.1</version>
+			<version>2.17.0</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Updates log4j to the latest 2.17 to fix the recently discovered vulnerabilities:

- CVE-2021-45046
- CVE-2021-44228